### PR TITLE
Switch from tox build wrapper to charmcraft.yaml overrides

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
           - .
           - tests/integration/application-charm
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v22.0.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
       cache: true
@@ -80,7 +80,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v22.0.0
     with:
       artifact-prefix: packed-charm-cache-true
       cloud: lxd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,14 +17,14 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v22.0.0
 
   release:
     name: Release charm
     needs:
       - ci-tests
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v22.0.0
     with:
       channel: 2/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,22 +3,6 @@
 
 type: charm
 parts:
-  files:
-    plugin: dump
-    source: .
-    build-packages:
-      - git
-    override-build: |
-      # Workaround to add unique identifier (git hash) to charm version while specification
-      # DA053 - Charm versioning
-      # (https://docs.google.com/document/d/1Jv1jhWLl8ejK3iJn7Q3VbCIM9GIhp8926bgXpdtx-Sg/edit?pli=1)
-      # is pending review.
-      python3 -c 'import pathlib; import shutil; import subprocess; git_hash=subprocess.run(["git", "describe", "--always", "--dirty"], capture_output=True, check=True, encoding="utf-8").stdout; file = pathlib.Path("charm_version"); shutil.copy(file, pathlib.Path("charm_version.backup")); version = file.read_text().strip(); file.write_text(f"{version}+{git_hash}")'
-      craftctl default
-    stage:
-      # Exclude requirements.txt file during staging
-      # Workaround for https://github.com/canonical/charmcraft/issues/1389 on charmcraft 2
-      - -requirements.txt
   charm:
     build-snaps:
       - rustup
@@ -33,9 +17,6 @@ parts:
       curl -sSL https://install.python-poetry.org | python3 -
       /root/.local/bin/poetry export --only main,charm-libs --output requirements.txt
       craftctl default
-    stage:
-      # Exclude charm_version file during staging
-      - -charm_version
     charm-strict-dependencies: true
     charm-requirements: [requirements.txt]
     charm-entrypoint: src/charm.py

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,23 +3,42 @@
 
 type: charm
 parts:
-  charm:
-    override-pull: |
+  files:
+    plugin: dump
+    source: .
+    build-packages:
+      - git
+    override-build: |
+      # Workaround to add unique identifier (git hash) to charm version while specification
+      # DA053 - Charm versioning
+      # (https://docs.google.com/document/d/1Jv1jhWLl8ejK3iJn7Q3VbCIM9GIhp8926bgXpdtx-Sg/edit?pli=1)
+      # is pending review.
+      python3 -c 'import pathlib; import shutil; import subprocess; git_hash=subprocess.run(["git", "describe", "--always", "--dirty"], capture_output=True, check=True, encoding="utf-8").stdout; file = pathlib.Path("charm_version"); shutil.copy(file, pathlib.Path("charm_version.backup")); version = file.read_text().strip(); file.write_text(f"{version}+{git_hash}")'
       craftctl default
-      if [[ ! -f requirements.txt ]]
-      then
-          echo 'ERROR: Use "tox run -e build-dev" instead of calling "charmcraft pack" directly' >&2
-          exit 1
-      fi
-    charm-strict-dependencies: true
-    charm-entrypoint: src/charm.py
+    stage:
+      # Exclude requirements.txt file during staging
+      # Workaround for https://github.com/canonical/charmcraft/issues/1389 on charmcraft 2
+      - -requirements.txt
+  charm:
+    build-snaps:
+      - rustup
     build-packages:
       - pkg-config
       - libffi-dev
       - libssl-dev
-      - rustc
-      - cargo
       - cmake
+    override-build: |
+      rustup default stable
+      # Convert subset of poetry.lock to requirements.txt
+      curl -sSL https://install.python-poetry.org | python3 -
+      /root/.local/bin/poetry export --only main,charm-libs --output requirements.txt
+      craftctl default
+    stage:
+      # Exclude charm_version file during staging
+      - -charm_version
+    charm-strict-dependencies: true
+    charm-requirements: [requirements.txt]
+    charm-entrypoint: src/charm.py
 bases:
   - build-on:
       - name: "ubuntu"

--- a/tox.ini
+++ b/tox.ini
@@ -21,32 +21,6 @@ set_env =
 pass_env =
     poetry
 
-[testenv:build-{production,dev,wrapper}]
-# Wrap `charmcraft pack`
-pass_env =
-    CI
-    GH_TOKEN
-allowlist_externals =
-    {[testenv]allowlist_externals}
-    charmcraft
-    charmcraftcache
-    mv
-commands_pre =
-    # TODO charm versioning: Remove
-    # Workaround to add unique identifier (git hash) to charm version while specification
-    # DA053 - Charm versioning
-    # (https://docs.google.com/document/d/1Jv1jhWLl8ejK3iJn7Q3VbCIM9GIhp8926bgXpdtx-Sg/edit?pli=1)
-    # is pending review.
-    python -c 'import pathlib; import shutil; import subprocess; git_hash=subprocess.run(["git", "describe", "--always", "--dirty"], capture_output=True, check=True, encoding="utf-8").stdout; file = pathlib.Path("charm_version"); shutil.copy(file, pathlib.Path("charm_version.backup")); version = file.read_text().strip(); file.write_text(f"{version}+{git_hash}")'
-
-    poetry export --only main,charm-libs --output requirements.txt
-commands =
-    build-production: charmcraft pack {posargs}
-    build-dev: charmcraftcache pack {posargs}
-commands_post =
-    mv requirements.txt requirements-last-build.txt
-    mv charm_version.backup charm_version
-
 [testenv:format]
 description = Apply coding style standards to code
 commands_pre =
@@ -89,12 +63,7 @@ set_env =
 pass_env =
     CI
     GITHUB_OUTPUT
-allowlist_externals =
-    {[testenv:build-wrapper]allowlist_externals}
 commands_pre =
     poetry install --only integration
-    {[testenv:build-wrapper]commands_pre}
 commands =
     poetry run pytest -vv --tb native --log-cli-level=INFO --ignore={[vars]tests_path}/unit/ {posargs} 
-commands_post =
-    {[testenv:build-wrapper]commands_post}


### PR DESCRIPTION
As defined by https://github.com/canonical/data-platform-workflows/releases/tag/v22.0.0 to support charmcraftcache-hub