### PR TITLE
Do not check the indexer's version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -25,7 +25,6 @@ from literals import (
     COS_RELATION_NAME,
     DEPENDENCIES,
     MSG_APP_STATUS,
-    MSG_INCOMPATIBLE_UPGRADE,
     MSG_INSTALLING,
     MSG_STARTING,
     MSG_STARTING_SERVER,
@@ -169,12 +168,6 @@ class OpensearchDasboardsCharm(CharmBase):
             outdated_status.append(MSG_STATUS_DB_MISSING)
         else:
             set_global_status(self, BlockedStatus(MSG_STATUS_DB_MISSING))
-            return
-
-        if self.upgrade_manager.version_compatible():
-            outdated_status.append(MSG_INCOMPATIBLE_UPGRADE)
-        else:
-            set_global_status(self, BlockedStatus(MSG_INCOMPATIBLE_UPGRADE))
             return
 
         # Maintain the correct unit status

--- a/src/events/upgrade.py
+++ b/src/events/upgrade.py
@@ -18,7 +18,6 @@ from charms.data_platform_libs.v0.upgrade import (
 from ops.model import BlockedStatus
 from typing_extensions import override
 
-from literals import MSG_INCOMPATIBLE_UPGRADE
 
 if TYPE_CHECKING:
     from charm import (
@@ -40,15 +39,6 @@ class ODUpgradeEvents(DataUpgrade):
     def __init__(self, charm: "OpensearchDashboardsCharm", **kwargs):
         super().__init__(charm, **kwargs)
         self.charm = charm
-
-    def post_upgrade_check(self) -> None:
-        """Runs necessary checks validating the unit is in a healthy state after upgrade."""
-        if not self.charm.upgrade_manager.version_compatible():
-            self.charm.unit.status = BlockedStatus(MSG_INCOMPATIBLE_UPGRADE)
-            raise ClusterNotReadyError(
-                message="Post-upgrade check failed and cannot safely upgrade",
-                cause="Opensearch version mismatch",
-            )
 
     @override
     def pre_upgrade_check(self) -> None:
@@ -93,9 +83,6 @@ class ODUpgradeEvents(DataUpgrade):
         self.charm.workload.restart()
 
         try:
-            logger.debug("Running post-upgrade check...")
-            self.post_upgrade_check()
-
             logger.debug("Marking unit completed...")
             self.set_unit_completed()
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -52,7 +52,6 @@ MSG_WAITING_FOR_PEER = "waiting for peer relation"
 MSG_STATUS_DB_MISSING = "Opensearch connection is missing"
 MSG_STATUS_DB_DOWN = "Opensearch service is (partially or fully) down"
 MSG_TLS_CONFIG = "Waiting for TLS to be fully configured..."
-MSG_INCOMPATIBLE_UPGRADE = "Incompatible Opensearch and Dashboards versions"
 
 MSG_STATUS_UNAVAIL = "Service unavailable"
 MSG_STATUS_UNHEALTHY = "Service is not in a green health state"


### PR DESCRIPTION
The indexer settings might affect the informed version number. https://github.com/canonical/wazuh-indexer-snap/pull/9 causes the check to fail