### PR TITLE
Document how to maintain the fork

### DIFF
--- a/CONTRIBUTING.fork.md
+++ b/CONTRIBUTING.fork.md
@@ -1,15 +1,15 @@
 # How to maintain the fork
 
 > [!IMPORTANT]
-> GitHub wrongly shows that the fork is based on the `main` branch of `opensearch-dashboards-operator`.
+> GitHub incorrectly shows that the fork is based on the `main` branch of `opensearch-dashboards-operator`.
 > `wazuh-dashboard-operator` is based on the `2/edge` branch.
 
 ## Prepare
 
-- Clone the repository if you don't already have it.
+- Clone the repository: `git clone https://github.com/canonical/wazuh-dashboard-operator.git`
 - Prepare your working branch: `git checkout -b chore/merge_upstram`
 - Ensure that all CI tests pass before changing anything. You can trigger the CI with an empty commit: `git commit --allow-empty -m 'Trigger CI' && git push -u origin chore/merge_upstram`.
-- Fetch upstream branch:
+- Fetch the upstream branch:
 
 ```shell
 git remote add upstream https://github.com/canonical/opensearch-dashboards-operator.git
@@ -21,8 +21,8 @@ git fetch upstream
 Start the merge with `git merge upstream/2/edge`.
 
 During the merge, you will face three potential conflicts:
-- You may want to keep the local version of a file, then use: `git checkout --ours <the-file>`
-- You may want to keep the upstream version of a file, then use: `git checkout --their <the-file>`
-- The file has to be manually edited to keep changes from both.
+- If you want to keep the local version of a file, then use: `git checkout --ours <the-file>`
+- If you want to keep the upstream version of a file, then use: `git checkout --their <the-file>`
+- If you want to keep changes from both versions, manually edit the file.
 
-Once you have fixed the conflict, `git add` the file and move to the next one.
+Once you have fixed the conflict, run the following command to add the file to the staging area and move to the next one: `git add <file_name>`

--- a/CONTRIBUTING.fork.md
+++ b/CONTRIBUTING.fork.md
@@ -1,0 +1,28 @@
+# How to maintain the fork
+
+> [!IMPORTANT]
+> GitHub wrongly shows that the fork is based on the `main` branch of `opensearch-dashboards-operator`.
+> `wazuh-dashboard-operator` is based on the `2/edge` branch.
+
+## Prepare
+
+- Clone the repository if you don't already have it.
+- Prepare your working branch: `git checkout -b chore/merge_upstram`
+- Ensure that all CI tests pass before changing anything. You can trigger the CI with an empty commit: `git commit --allow-empty -m 'Trigger CI' && git push -u origin chore/merge_upstram`.
+- Fetch upstream branch:
+
+```shell
+git remote add upstream https://github.com/canonical/opensearch-dashboards-operator.git
+git fetch upstream
+```
+
+## Merge
+
+Start the merge with `git merge upstream/2/edge`.
+
+During the merge, you will face three potential conflicts:
+- You may want to keep the local version of a file, then use: `git checkout --ours <the-file>`
+- You may want to keep the upstream version of a file, then use: `git checkout --their <the-file>`
+- The file has to be manually edited to keep changes from both.
+
+Once you have fixed the conflict, `git add` the file and move to the next one.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Follow instructions from Wazuh documentation on
 When the index pattern is defined, data that belongs to the user will display in the Dasboards.
 
 
-# Contributing
+# Contribute
 
 `wazuh-dashboard-operator` is a fork of [`opensearch-dashboards-operator`](https://github.com/canonical/opensearch-dashboards-operator). If you're interested in adding non Wazuh specific features to the charm, consider contributing upstream.
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Follow instructions from Wazuh documentation on
 When the index pattern is defined, data that belongs to the user will display in the Dasboards.
 
 
+# Contributing
+
+`wazuh-dashboard-operator` is a fork of [`opensearch-dashboards-operator`](https://github.com/canonical/opensearch-dashboards-operator). If you're interested in adding non Wazuh specific features to the charm, consider contributing upstream.
+
+The maintenance of the fork is documented in [CONTRIBUTING.fork.md](CONTRIBUTING.fork.md).
+
 # License
 
 The Charmed Wazuh Dashboard Operator is free software, distributed under the Apache


### PR DESCRIPTION
Bootstrap a documentation on how to maintain the fork. It should be enriched every time we do it to make it simpler for future team members.