### PR TITLE
Fix Wazuh configuration disappearing from config file

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/src/charm.py
+++ b/src/charm.py
@@ -309,6 +309,7 @@ class OpensearchDasboardsCharm(CharmBase):
 
         logger.debug("setting properties")
         self.config_manager.set_dashboard_properties()
+        self.wazuh_api_events.update_configuration()
 
         logger.debug("starting Opensearch Dashboards service")
 

--- a/src/events/wazuh_api.py
+++ b/src/events/wazuh_api.py
@@ -34,6 +34,10 @@ class WazuhApiEvents(Object):
 
     def _on_wazuh_api_relation_changed(self, _: RelationEvent) -> None:
         """Handler for `wazuh-api` relation creation and changes."""
+        self.update_configuration()
+
+    def update_configuration(self) -> None:
+        """Update configuration from relation data."""
         data = self.wazuh_api.get_relation_data()
         if data:
             self.charm.wazuh_manager.set_dashboard_properties(data)


### PR DESCRIPTION
The Wazuh configuration changes were undone when the a reconcile was triggered while the process was down